### PR TITLE
Add a menu item to sign out and wipeout the local database.

### DIFF
--- a/client/lib/pages/home/home.dart
+++ b/client/lib/pages/home/home.dart
@@ -4,6 +4,7 @@ import 'package:gonna_client/pages/create/create.dart';
 import 'package:gonna_client/services/auth/auth.dart';
 import 'package:gonna_client/services/background/background.dart';
 import 'package:gonna_client/services/contact_sync/contact_sync.dart' as contact_sync;
+import 'package:gonna_client/services/wipeout/wipeout.dart';
 
 class HomePage extends StatefulWidget {
   @override
@@ -74,6 +75,10 @@ class _HomePageState extends State<HomePage> {
         ListTile(
           title: Text('Delete Account'),
           onTap: () => AuthService.instance.deleteAccount(),
+        ),
+        ListTile(
+          title: Text('Signout and Wipeout'),
+          onTap: () => WipeoutService.signoutAndWipeoutDatabase(),
         ),
       ],
     ));

--- a/client/lib/services/database/database.dart
+++ b/client/lib/services/database/database.dart
@@ -66,6 +66,12 @@ LazyDatabase _openConnection() {
   });
 }
 
+Future<void> _deleteDatabase() async {
+  final dbFolder = await getApplicationDocumentsDirectory();
+  final file = File(p.join(dbFolder.path, 'gonna.sqlite'));
+  await file.delete();
+}
+
 @DriftDatabase(tables: [AppState, Contacts], daos: [AppStateDao, ContactsDao])
 class GonnaDatabase extends _$GonnaDatabase {
 
@@ -82,4 +88,9 @@ class GonnaDatabase extends _$GonnaDatabase {
 
   @override
   int get schemaVersion => 1;
+
+  closeAndDelete() async {
+    await close();
+    await _deleteDatabase();
+  }
 }

--- a/client/lib/services/storage/storage.dart
+++ b/client/lib/services/storage/storage.dart
@@ -18,9 +18,13 @@ class StorageService {
 
   Future<void> uploadProfilePicture(File profilePicture) async {
     if (_auth.currentUser == null) {
-      throw new Exception('Cant upload profile photo without authenticated user.');
+      throw new Exception(
+          'Cant upload profile photo without authenticated user.');
     }
-    await _storage.ref('profileImage/${_auth.currentUser!.uid}').putFile(profilePicture);
+    await _storage
+        .ref('profileImage/${_auth.currentUser!.uid}')
+        .putFile(profilePicture);
+    ;
     print('Finished uploading the image');
   }
 }

--- a/client/lib/services/wipeout/wipeout.dart
+++ b/client/lib/services/wipeout/wipeout.dart
@@ -1,0 +1,9 @@
+import 'package:gonna_client/services/auth/auth.dart' as auth;
+import 'package:gonna_client/services/database/database.dart';
+
+class WipeoutService {
+  static signoutAndWipeoutDatabase() {
+    auth.AuthService.instance.signOut();
+    GonnaDatabase.instance.closeAndDelete();
+  }
+}


### PR DESCRIPTION
This should help clear the sqlite database when iterating over schema design in dev phones.